### PR TITLE
resolve the dropdown hidden feature #322

### DIFF
--- a/404.html
+++ b/404.html
@@ -42,13 +42,14 @@
                         </li>
                     </ul>
                 </li>
-                <li class="community">
+                <li class="community ">
                     <a href="maintenance.html">Join Our Community</a>
-                    <ul class="dropdown">
-                        <li><a href="maintenance.html">WhatsApp</a></li>
-                        <li><a href="maintenance.html">Discord</a></li>
+                    <ul class="dropdown absolute hidden bg-white shadow-lg">
+                        <li class="p-2"><a href="maintenance.html">WhatsApp</a></li>
+                        <li class="p-2"><a href="maintenance.html">Discord</a></li>
                     </ul>
                 </li>
+                
                 <li>
                     <a href="maintenance.html">Meet Our Team</a>
                 </li>

--- a/styles.css
+++ b/styles.css
@@ -426,6 +426,16 @@ body.dark-mode .calendar-day:hover {
   position: relative;
   display: inline-block;
 }
+/* Initially hide the dropdown */
+.navbar ul li .dropdown {
+  display: none;
+}
+
+/* Show the dropdown on hover */
+.navbar ul li:hover .dropdown {
+  display: block;
+}
+
 .navbar ul li:hover {
   transform: scale(1.1);
 }


### PR DESCRIPTION
Dropdown menus visible by default on page load without hover interaction

Issue:
The dropdown menus in the navigation bar are visible immediately after the page is refreshed, without any hover interaction from the user. This causes the dropdown items to be displayed even when they are not needed, cluttering the page layout.

Expected Behavior:
Dropdown menus should be hidden by default and only appear when the user hovers over the respective menu items.

Steps to Reproduce:
Load or refresh the webpage.
Observe that the dropdown menus under navigation items are visible without hovering.
Potential Fix:
The issue seems to be caused by the lack of default display: none; styling for the dropdown menus in the CSS. Adding CSS rules to hide the dropdown by default and show them only on hover should fix the issue.
<img width="1680" alt="Screenshot 2024-10-21 at 11 54 59 AM" src="https://github.com/user-attachments/assets/21ae6001-7cae-4d72-90de-6ccc89d6db59">
<img width="1680" alt="Screenshot 2024-10-21 at 11 55 05 AM" src="https://github.com/user-attachments/assets/8e4b6bdb-231e-46f1-ad77-9e8a3e9d1ba6">
#322 