### PR TITLE
[FIXED] Fixing the height of the "about community" #439

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -836,7 +836,7 @@ body.dark-mode #theme-switch {
   text-align: center;
   margin: 20px auto;
   max-width: 1400px;
-  height: calc(100vh - 100px); 
+  height: 600px; 
   border-radius: 20px;
   box-shadow: 20px 20px 60px rgba(0, 0, 0, 0.3);
   transition: transform 0.3s ease;


### PR DESCRIPTION
## Related Issue:

- #439 

Fixes issue: #439 

## Description:

The height of the about community element in the homepage was changed in order to make it smaller so that it doesn't take up the entire screen and looks visually appealing to the user.

## Screenshots

Before:
<img width="1800" alt="Screenshot 2024-10-27 at 5 39 02 PM" src="https://github.com/user-attachments/assets/adc7f5ec-f3bf-4f48-9635-d978691a4625">
After:
<img width="1800" alt="Screenshot 2024-10-27 at 5 38 54 PM" src="https://github.com/user-attachments/assets/ff0da850-53f8-4a4a-b837-8664cf75be29">