### PR TITLE
fix: fixes nav bar visibility in light mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
        pointer-events: none; /* Disable interaction */
        }
     </style>
-    <style>
+    <!-- <style>
         html {
             scroll-behavior: smooth;
         }
@@ -120,7 +120,7 @@
             transition: width 0.09s ease-in-out;
             border-radius: 10px;
         }
-    </style>
+    </style> -->
     <style>
         html {
             scroll-behavior: smooth;

--- a/styles.css
+++ b/styles.css
@@ -564,9 +564,6 @@ body.dark-mode .calendar-day:hover {
 .navbar ul li .dropdown {
   display: none;
 }
-.navbar ul a {
-    color: white;
-}
 
 /* Show the dropdown on hover */
 .navbar ul li:hover .dropdown {


### PR DESCRIPTION
- Fixes #470 
- The issue was the property set for navbar font in general
- The property was set such that the font is always white, overriding the changes made in light or dark mode
- Removing that fixed the issue
- Reviewers: @Rizwan102003 @arushi2610 @pulkitpathak99 
- Additionally, there was some redundant css written in index.html, so commented it, since it was unnecessary

**Screenshots**

![Screenshot 2024-10-30 at 4 09 25 PM](https://github.com/user-attachments/assets/c4706dcd-2782-4485-bded-7ac8970a6ac1)
![Screenshot 2024-10-30 at 4 10 10 PM](https://github.com/user-attachments/assets/092e6d37-8b08-4448-b1c9-bd3c5b1ab17c)
